### PR TITLE
feat: 优化错题本筛选交互与主题分组展示

### DIFF
--- a/src/__tests__/mistakeFilters.test.ts
+++ b/src/__tests__/mistakeFilters.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { MistakeRecord } from '@/hooks/useUserProgress';
+import {
+  buildPracticeQueue,
+  filterMistakes,
+  getAvailableChoiceTopics,
+  getQuestionKind,
+} from '@/lib/mistakeFilters';
+
+const makeRecord = (overrides: Partial<MistakeRecord>): MistakeRecord => ({
+  questionId: overrides.questionId ?? 'q1',
+  topicId: overrides.topicId ?? 'values',
+  count: overrides.count ?? 1,
+  lastWrongAt: overrides.lastWrongAt ?? 100,
+  question: overrides.question ?? {
+    id: overrides.questionId ?? 'q1',
+    type: 'single',
+    stem: 'question',
+    analysis: 'analysis',
+    choices: [
+      { id: 'c1', text: 'A', isCorrect: true },
+      { id: 'c2', text: 'B', isCorrect: false },
+    ],
+  },
+});
+
+describe('mistakeFilters', () => {
+  it('can classify question kind by topic', () => {
+    expect(getQuestionKind('situation')).toBe('situation');
+    expect(getQuestionKind('history')).toBe('choice');
+  });
+
+  it('filters by question kind and min wrong count', () => {
+    const records = [
+      makeRecord({ questionId: 'q1', topicId: 'history', count: 3 }),
+      makeRecord({ questionId: 'q2', topicId: 'situation', count: 2 }),
+      makeRecord({ questionId: 'q3', topicId: 'values', count: 1 }),
+    ];
+
+    const filtered = filterMistakes(records, { kind: 'choice', minWrongCount: 2 });
+    expect(filtered.map((item) => item.questionId)).toEqual(['q1']);
+  });
+
+  it('returns de-duplicated choice topics only', () => {
+    const records = [
+      makeRecord({ topicId: 'history' }),
+      makeRecord({ topicId: 'history', questionId: 'q2' }),
+      makeRecord({ topicId: 'situation', questionId: 'q3' }),
+      makeRecord({ topicId: 'values', questionId: 'q4' }),
+    ];
+
+    expect(getAvailableChoiceTopics(records)).toEqual(['history', 'values']);
+  });
+
+  it('builds review queue by count first then time', () => {
+    const records = [
+      makeRecord({ questionId: 'q1', count: 2, lastWrongAt: 100 }),
+      makeRecord({ questionId: 'q2', count: 4, lastWrongAt: 20 }),
+      makeRecord({ questionId: 'q3', count: 2, lastWrongAt: 500 }),
+    ];
+
+    const queue = buildPracticeQueue(records, 'review');
+    expect(queue.map((item) => item.questionId)).toEqual(['q2', 'q3', 'q1']);
+  });
+
+  it('builds weighted sprint queue', () => {
+    const records = [
+      makeRecord({ questionId: 'q1', count: 1 }),
+      makeRecord({ questionId: 'q2', count: 3 }),
+    ];
+
+    const queue = buildPracticeQueue(records, 'sprint', () => 0.5);
+
+    const q1Count = queue.filter((item) => item.questionId === 'q1').length;
+    const q2Count = queue.filter((item) => item.questionId === 'q2').length;
+
+    expect(q1Count).toBe(1);
+    expect(q2Count).toBe(3);
+    expect(queue).toHaveLength(4);
+  });
+});

--- a/src/components/exam/MistakesPracticeCard.tsx
+++ b/src/components/exam/MistakesPracticeCard.tsx
@@ -2,169 +2,434 @@
 
 import { useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowRight, CheckCircle2, XCircle, RotateCcw } from 'lucide-react';
+import {
+  ArrowRight,
+  ChevronDown,
+  CheckCircle2,
+  XCircle,
+  RotateCcw,
+  Filter,
+  Zap,
+} from 'lucide-react';
 import BookmarkButton from '@/components/quiz/BookmarkButton';
 import { useUserProgress } from '@/hooks/useUserProgress';
+import {
+  buildPracticeQueue,
+  filterMistakes,
+  isSituationTopic,
+  MistakeQuestionKind,
+  PracticeMode,
+} from '@/lib/mistakeFilters';
+
+type WrongCountFilter = 1 | 2 | 3 | 5;
+
+const TOPIC_CN: Record<string, string> = {
+  values: '原则与价值观',
+  institutions: '制度体系',
+  rights: '权利与义务',
+  history: '历史与文化',
+  society: '法国社会',
+  'daily-practice': '每日练习',
+  situation: '情景题',
+};
+
+const KIND_FILTERS: Array<{ value: MistakeQuestionKind; label: string }> = [
+  { value: 'all', label: '全部' },
+  { value: 'choice', label: '选择题' },
+  { value: 'situation', label: '情景题' },
+];
+
+const COUNT_FILTERS: Array<{ value: WrongCountFilter; label: string }> = [
+  { value: 1, label: '全部次数' },
+  { value: 2, label: '错 >= 2 次' },
+  { value: 3, label: '错 >= 3 次' },
+  { value: 5, label: '错 >= 5 次' },
+];
+
+const MODES: Array<{ value: PracticeMode; label: string; description: string }> = [
+  { value: 'review', label: '复习模式', description: '按错误次数与最近错题顺序刷题' },
+  { value: 'sprint', label: '冲刺模式', description: '高频错题加权重复，答错会再次出现' },
+];
+
+function getTopicOptions(topicIds: string[], kind: MistakeQuestionKind): string[] {
+  return Array.from(new Set(topicIds.filter((topicId) => {
+    if (kind === 'choice') return !isSituationTopic(topicId);
+    if (kind === 'situation') return isSituationTopic(topicId);
+    return true;
+  })));
+}
+
+function isTopicAllowedInKind(topicId: string, kind: MistakeQuestionKind): boolean {
+  if (topicId === 'all') return true;
+  if (kind === 'all') return true;
+  if (kind === 'choice') return !isSituationTopic(topicId);
+  return isSituationTopic(topicId);
+}
 
 export default function MistakesPracticeCard() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
   const [showAnswer, setShowAnswer] = useState(false);
+  const [kindFilter, setKindFilter] = useState<MistakeQuestionKind>('all');
+  const [topicFilter, setTopicFilter] = useState<string>('all');
+  const [minWrongCount, setMinWrongCount] = useState<WrongCountFilter>(1);
+  const [mode, setMode] = useState<PracticeMode>('review');
+  const [showFilters, setShowFilters] = useState(true);
+  const [extraQueue, setExtraQueue] = useState<string[]>([]);
+  const [sessionAnswered, setSessionAnswered] = useState(0);
+  const [sessionCorrect, setSessionCorrect] = useState(0);
 
-  const {
-    mistakes,
-    isBookmarked,
-    toggleBookmark,
-    removeMistake,
-  } = useUserProgress();
+  const { mistakes, isBookmarked, toggleBookmark, removeMistake } = useUserProgress();
 
-  const mistakeList = useMemo(
-    () => Object.values(mistakes).sort((a, b) => b.lastWrongAt - a.lastWrongAt),
+  const sortedMistakes = useMemo(
+    () => Object.values(mistakes).sort((a, b) => b.count - a.count || b.lastWrongAt - a.lastWrongAt),
     [mistakes]
   );
 
-  if (mistakeList.length === 0) {
-    return (
-      <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-10 text-center text-emerald-900">
-        <h2 className="text-2xl font-bold">错题本为空</h2>
-        <p className="mt-3 text-sm text-emerald-800">当前没有可刷的错题。先去主题练习或模拟考试累积错题。</p>
-      </div>
-    );
-  }
+  const topicOptions = useMemo(
+    () => getTopicOptions(sortedMistakes.map((record) => record.topicId), kindFilter),
+    [sortedMistakes, kindFilter]
+  );
 
-  const safeIndex = currentIndex % mistakeList.length;
-  const currentRecord = mistakeList[safeIndex];
-  const currentQuestion = currentRecord.question;
-  const bookmarked = isBookmarked(currentQuestion.id);
+  const filteredRecords = useMemo(
+    () => filterMistakes(sortedMistakes, { kind: kindFilter, topicId: topicFilter, minWrongCount }),
+    [sortedMistakes, kindFilter, topicFilter, minWrongCount]
+  );
+
+  const filteredMap = useMemo(() => {
+    const map = new Map<string, (typeof filteredRecords)[number]>();
+    filteredRecords.forEach((record) => map.set(record.questionId, record));
+    return map;
+  }, [filteredRecords]);
+
+  const baseQueue = useMemo(() => buildPracticeQueue(filteredRecords, mode), [filteredRecords, mode]);
+
+  const replayQueue = useMemo(() => {
+    return extraQueue
+      .map((questionId) => filteredMap.get(questionId))
+      .filter((item): item is NonNullable<typeof item> => Boolean(item));
+  }, [extraQueue, filteredMap]);
+
+  const queue = useMemo(() => [...baseQueue, ...replayQueue], [baseQueue, replayQueue]);
+
+  const safeIndex = queue.length > 0 ? currentIndex % queue.length : 0;
+  const currentRecord = queue[safeIndex];
+  const currentQuestion = currentRecord?.question;
+
+  const resetSession = () => {
+    setCurrentIndex(0);
+    setSelectedChoice(null);
+    setShowAnswer(false);
+    setExtraQueue([]);
+    setSessionAnswered(0);
+    setSessionCorrect(0);
+  };
+
+  const handleChangeKind = (nextKind: MistakeQuestionKind) => {
+    const finalKind = kindFilter === nextKind ? 'all' : nextKind;
+    setKindFilter(finalKind);
+    if (!isTopicAllowedInKind(topicFilter, finalKind)) {
+      setTopicFilter('all');
+    }
+    resetSession();
+  };
+
+  const handleChangeTopic = (nextTopic: string) => {
+    setTopicFilter((prev) => (prev === nextTopic ? 'all' : nextTopic));
+    resetSession();
+  };
+
+  const handleChangeMinWrongCount = (nextValue: WrongCountFilter) => {
+    setMinWrongCount((prev) => (prev === nextValue ? 1 : nextValue));
+    resetSession();
+  };
+
+  const handleChangeMode = (nextMode: PracticeMode) => {
+    setMode(nextMode);
+    resetSession();
+  };
 
   const handleSelectChoice = (choiceId: string) => {
-    if (showAnswer) return;
+    if (showAnswer || !currentQuestion || !currentRecord) return;
+
+    const choice = currentQuestion.choices.find((item) => item.id === choiceId);
+    const isCorrect = Boolean(choice?.isCorrect);
+
     setSelectedChoice(choiceId);
     setShowAnswer(true);
+    setSessionAnswered((prev) => prev + 1);
+    if (isCorrect) {
+      setSessionCorrect((prev) => prev + 1);
+    } else if (mode === 'sprint') {
+      setExtraQueue((prev) => [...prev, currentRecord.questionId]);
+    }
   };
 
   const handleNext = () => {
-    setCurrentIndex((prev) => (prev + 1) % mistakeList.length);
+    if (queue.length === 0) return;
+    setCurrentIndex((prev) => (prev + 1) % queue.length);
     setSelectedChoice(null);
     setShowAnswer(false);
   };
 
   const handleMarkMastered = () => {
+    if (!currentRecord || !currentQuestion) return;
     removeMistake(currentQuestion.id);
+    setExtraQueue((prev) => prev.filter((questionId) => questionId !== currentRecord.questionId));
+
     setSelectedChoice(null);
     setShowAnswer(false);
     setCurrentIndex(0);
   };
 
-  return (
-    <div className="relative rounded-3xl border border-white/70 bg-white/85 p-8 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.55)] backdrop-blur">
-      <div className="absolute right-4 top-4">
-        <BookmarkButton
-          isActive={bookmarked}
-          onClick={() => toggleBookmark(currentQuestion, currentRecord.topicId)}
-        />
-      </div>
-
-      <div className="pr-12">
-        <span className="rounded-full bg-gradient-to-r from-red-600 to-orange-500 px-3 py-1 text-xs font-semibold text-white">
-          错题本练习
-        </span>
-        <p className="mt-3 text-sm text-slate-500">
-          第 {safeIndex + 1} / {mistakeList.length} 题 · 累计错 {currentRecord.count} 次
-        </p>
-      </div>
-
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={`${currentQuestion.id}-${currentRecord.lastWrongAt}`}
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -20 }}
-          transition={{ duration: 0.2 }}
-        >
-          <p className="mt-6 text-xl font-semibold leading-relaxed text-slate-900 sm:text-2xl">
-            {currentQuestion.stem}
-          </p>
-
-          <div className="mt-6 space-y-3">
-            {currentQuestion.choices.map((choice) => {
-              const isSelected = selectedChoice === choice.id;
-              const isCorrect = choice.isCorrect;
-
-              let buttonStyle = 'border-slate-200 bg-white hover:bg-slate-50 hover:border-slate-300 text-slate-700';
-
-              if (showAnswer) {
-                if (isSelected && isCorrect) {
-                  buttonStyle = 'border-green-500 bg-green-50 text-green-800 ring-1 ring-green-500';
-                } else if (isSelected && !isCorrect) {
-                  buttonStyle = 'border-red-500 bg-red-50 text-red-800 ring-1 ring-red-500';
-                } else if (!isSelected && isCorrect) {
-                  buttonStyle = 'border-green-200 bg-green-50/50 text-green-700';
-                } else {
-                  buttonStyle = 'border-slate-100 bg-slate-50 text-slate-400 opacity-60';
-                }
-              }
-
-              return (
+  if (filteredRecords.length === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-3xl border border-slate-200 bg-white p-5">
+          <button
+            onClick={() => setShowFilters((prev) => !prev)}
+            className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-200"
+          >
+            <Filter className="mr-1.5 h-3.5 w-3.5" />
+            {showFilters ? '收起筛选' : '展开筛选'}
+            <ChevronDown
+              className={`ml-1.5 h-3.5 w-3.5 transition-transform ${showFilters ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {showFilters && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {KIND_FILTERS.map((item) => (
                 <button
-                  key={choice.id}
-                  onClick={() => handleSelectChoice(choice.id)}
-                  disabled={showAnswer}
-                  className={`group relative flex w-full items-center rounded-xl border p-4 text-left text-base font-medium transition-all ${buttonStyle}`}
+                  key={item.value}
+                  onClick={() => handleChangeKind(item.value)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                    kindFilter === item.value
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  }`}
                 >
-                  <span className="flex-1">{choice.text}</span>
-                  {showAnswer && isSelected && isCorrect && (
-                    <CheckCircle2 className="ml-3 h-5 w-5 text-green-600" />
-                  )}
-                  {showAnswer && isSelected && !isCorrect && (
-                    <XCircle className="ml-3 h-5 w-5 text-red-600" />
-                  )}
-                  {showAnswer && !isSelected && isCorrect && (
-                    <CheckCircle2 className="ml-3 h-5 w-5 text-green-600" />
-                  )}
+                  {item.label}
                 </button>
-              );
-            })}
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-10 text-center text-emerald-900">
+          <h2 className="text-2xl font-bold">当前筛选下暂无错题</h2>
+          <p className="mt-3 text-sm text-emerald-800">可以切换筛选条件，或先去主题练习/模拟考试积累错题。</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!currentRecord || !currentQuestion) {
+    return null;
+  }
+
+  const bookmarked = isBookmarked(currentQuestion.id);
+  const accuracy = sessionAnswered > 0 ? Math.round((sessionCorrect / sessionAnswered) * 100) : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-3xl border border-slate-200 bg-white p-5">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <button
+            onClick={() => setShowFilters((prev) => !prev)}
+            className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-200"
+          >
+            <Filter className="mr-1.5 h-3.5 w-3.5" />
+            {showFilters ? '收起筛选' : '展开筛选'}
+            <ChevronDown
+              className={`ml-1.5 h-3.5 w-3.5 transition-transform ${showFilters ? 'rotate-180' : ''}`}
+            />
+          </button>
+          <div className="text-xs text-slate-500">
+            本轮作答 {sessionAnswered} 题 · 正确率 {accuracy}%
           </div>
+        </div>
 
-          <AnimatePresence>
-            {showAnswer && currentQuestion.analysis && (
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
-                exit={{ opacity: 0, height: 0 }}
-                className="mt-6 overflow-hidden rounded-2xl bg-blue-50 p-4 text-blue-800"
-              >
-                <h3 className="mb-2 font-semibold">解析</h3>
-                <p className="text-sm">{currentQuestion.analysis}</p>
-              </motion.div>
+        {showFilters && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              {MODES.map((item) => (
+                <button
+                  key={item.value}
+                  onClick={() => handleChangeMode(item.value)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                    mode === item.value
+                      ? 'bg-purple-100 text-purple-700'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  }`}
+                  title={item.description}
+                >
+                  {item.value === 'sprint' && <Zap className="mr-1 inline h-3.5 w-3.5" />}
+                  {item.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {KIND_FILTERS.map((item) => (
+                <button
+                  key={item.value}
+                  onClick={() => handleChangeKind(item.value)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                    kindFilter === item.value
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+
+            {topicOptions.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {topicOptions.map((topicId) => (
+                  <button
+                    key={topicId}
+                    onClick={() => handleChangeTopic(topicId)}
+                    className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                      topicFilter === topicId
+                        ? 'bg-indigo-100 text-indigo-700'
+                        : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                    }`}
+                  >
+                    {TOPIC_CN[topicId] || topicId}
+                  </button>
+                ))}
+              </div>
             )}
-          </AnimatePresence>
-        </motion.div>
-      </AnimatePresence>
 
-      <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-        {showAnswer && (
-          <>
-            <button
-              className="inline-flex items-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-              onClick={handleMarkMastered}
-              type="button"
-            >
-              <RotateCcw className="mr-2 h-4 w-4" />
-              标记已掌握
-            </button>
-            <button
-              className="inline-flex items-center rounded-full bg-slate-900 px-8 py-3 text-base font-semibold text-white transition hover:bg-slate-800 active:scale-95"
-              onClick={handleNext}
-              type="button"
-            >
-              下一题
-              <ArrowRight className="ml-2 h-5 w-5" />
-            </button>
-          </>
+            <div className="flex flex-wrap gap-2">
+              {COUNT_FILTERS.map((item) => (
+                <button
+                  key={item.value}
+                  onClick={() => handleChangeMinWrongCount(item.value)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                    minWrongCount === item.value
+                      ? 'bg-amber-100 text-amber-700'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
         )}
-        {!showAnswer && <p className="text-sm text-slate-500">请选择一个选项作答</p>}
+      </div>
+
+      <div className="relative rounded-3xl border border-white/70 bg-white/85 p-8 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.55)] backdrop-blur">
+        <div className="absolute right-4 top-4">
+          <BookmarkButton
+            isActive={bookmarked}
+            onClick={() => toggleBookmark(currentQuestion, currentRecord.topicId)}
+          />
+        </div>
+
+        <div className="pr-12">
+          <span className="rounded-full bg-gradient-to-r from-red-600 to-orange-500 px-3 py-1 text-xs font-semibold text-white">
+            {mode === 'sprint' ? '错题冲刺' : '错题本复习'}
+          </span>
+          <p className="mt-3 text-sm text-slate-500">
+            第 {safeIndex + 1} / {queue.length} 题 · 题目累计错 {currentRecord.count} 次
+          </p>
+        </div>
+
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={`${currentQuestion.id}-${safeIndex}`}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.2 }}
+          >
+            <p className="mt-6 text-xl font-semibold leading-relaxed text-slate-900 sm:text-2xl">
+              {currentQuestion.stem}
+            </p>
+
+            <div className="mt-6 space-y-3">
+              {currentQuestion.choices.map((choice) => {
+                const isSelected = selectedChoice === choice.id;
+                const isCorrect = choice.isCorrect;
+
+                let buttonStyle = 'border-slate-200 bg-white hover:bg-slate-50 hover:border-slate-300 text-slate-700';
+
+                if (showAnswer) {
+                  if (isSelected && isCorrect) {
+                    buttonStyle = 'border-green-500 bg-green-50 text-green-800 ring-1 ring-green-500';
+                  } else if (isSelected && !isCorrect) {
+                    buttonStyle = 'border-red-500 bg-red-50 text-red-800 ring-1 ring-red-500';
+                  } else if (!isSelected && isCorrect) {
+                    buttonStyle = 'border-green-200 bg-green-50/50 text-green-700';
+                  } else {
+                    buttonStyle = 'border-slate-100 bg-slate-50 text-slate-400 opacity-60';
+                  }
+                }
+
+                return (
+                  <button
+                    key={choice.id}
+                    onClick={() => handleSelectChoice(choice.id)}
+                    disabled={showAnswer}
+                    className={`group relative flex w-full items-center rounded-xl border p-4 text-left text-base font-medium transition-all ${buttonStyle}`}
+                  >
+                    <span className="flex-1">{choice.text}</span>
+                    {showAnswer && isSelected && isCorrect && (
+                      <CheckCircle2 className="ml-3 h-5 w-5 text-green-600" />
+                    )}
+                    {showAnswer && isSelected && !isCorrect && (
+                      <XCircle className="ml-3 h-5 w-5 text-red-600" />
+                    )}
+                    {showAnswer && !isSelected && isCorrect && (
+                      <CheckCircle2 className="ml-3 h-5 w-5 text-green-600" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            <AnimatePresence>
+              {showAnswer && currentQuestion.analysis && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  className="mt-6 overflow-hidden rounded-2xl bg-blue-50 p-4 text-blue-800"
+                >
+                  <h3 className="mb-2 font-semibold">解析</h3>
+                  <p className="text-sm">{currentQuestion.analysis}</p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </AnimatePresence>
+
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          {showAnswer && (
+            <>
+              <button
+                className="inline-flex items-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                onClick={handleMarkMastered}
+                type="button"
+              >
+                <RotateCcw className="mr-2 h-4 w-4" />
+                标记已掌握
+              </button>
+              <button
+                className="inline-flex items-center rounded-full bg-slate-900 px-8 py-3 text-base font-semibold text-white transition hover:bg-slate-800 active:scale-95"
+                onClick={handleNext}
+                type="button"
+              >
+                下一题
+                <ArrowRight className="ml-2 h-5 w-5" />
+              </button>
+            </>
+          )}
+          {!showAnswer && <p className="text-sm text-slate-500">请选择一个选项作答</p>}
+        </div>
       </div>
     </div>
   );

--- a/src/lib/mistakeFilters.ts
+++ b/src/lib/mistakeFilters.ts
@@ -1,0 +1,95 @@
+import { MistakeRecord } from '@/hooks/useUserProgress';
+
+export type MistakeQuestionKind = 'all' | 'choice' | 'situation';
+export type PracticeMode = 'review' | 'sprint';
+
+export interface MistakeFilterOptions {
+  kind?: MistakeQuestionKind;
+  topicId?: string;
+  minWrongCount?: number;
+}
+
+export function isSituationTopic(topicId: string): boolean {
+  return topicId === 'situation';
+}
+
+export function getQuestionKind(topicId: string): Exclude<MistakeQuestionKind, 'all'> {
+  return isSituationTopic(topicId) ? 'situation' : 'choice';
+}
+
+export function getAvailableChoiceTopics(records: MistakeRecord[]): string[] {
+  const topics = records
+    .map((record) => record.topicId)
+    .filter((topicId) => !isSituationTopic(topicId));
+
+  return Array.from(new Set(topics));
+}
+
+export function filterMistakes(records: MistakeRecord[], options: MistakeFilterOptions): MistakeRecord[] {
+  const {
+    kind = 'all',
+    topicId = 'all',
+    minWrongCount = 1,
+  } = options;
+
+  return records.filter((record) => {
+    if (record.count < minWrongCount) {
+      return false;
+    }
+
+    const recordKind = getQuestionKind(record.topicId);
+
+    if (kind !== 'all' && recordKind !== kind) {
+      return false;
+    }
+
+    if (topicId !== 'all' && record.topicId !== topicId) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function shuffleArray<T>(items: T[], randomFn: () => number): T[] {
+  const copied = [...items];
+  for (let i = copied.length - 1; i > 0; i--) {
+    const j = Math.floor(randomFn() * (i + 1));
+    [copied[i], copied[j]] = [copied[j], copied[i]];
+  }
+  return copied;
+}
+
+function buildReviewQueue(records: MistakeRecord[]): MistakeRecord[] {
+  return [...records].sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+    return b.lastWrongAt - a.lastWrongAt;
+  });
+}
+
+function buildSprintQueue(records: MistakeRecord[], randomFn: () => number): MistakeRecord[] {
+  const weighted: MistakeRecord[] = [];
+
+  for (const record of records) {
+    const weight = Math.min(5, Math.max(1, record.count));
+    for (let i = 0; i < weight; i++) {
+      weighted.push(record);
+    }
+  }
+
+  return shuffleArray(weighted, randomFn);
+}
+
+export function buildPracticeQueue(
+  records: MistakeRecord[],
+  mode: PracticeMode,
+  randomFn: () => number = Math.random
+): MistakeRecord[] {
+  if (mode === 'sprint') {
+    return buildSprintQueue(records, randomFn);
+  }
+
+  return buildReviewQueue(records);
+}


### PR DESCRIPTION
## 变更内容\n- 错题本列表支持按主题分组展示\n- 筛选面板支持展开/收起\n- 错题刷题页筛选面板支持展开/收起\n- 新增错题筛选与练习队列工具及测试\n\n## 验证\n- npm run test -- --run\n- npm run build