### PR TITLE
feat: 学习管理模块升级 + 错题复习随机出题

### DIFF
--- a/src/__tests__/mistakeFilters.test.ts
+++ b/src/__tests__/mistakeFilters.test.ts
@@ -52,7 +52,7 @@ describe('mistakeFilters', () => {
     expect(getAvailableChoiceTopics(records)).toEqual(['history', 'values']);
   });
 
-  it('builds review queue by count first then time', () => {
+  it('builds review queue containing all records (shuffled)', () => {
     const records = [
       makeRecord({ questionId: 'q1', count: 2, lastWrongAt: 100 }),
       makeRecord({ questionId: 'q2', count: 4, lastWrongAt: 20 }),
@@ -60,7 +60,9 @@ describe('mistakeFilters', () => {
     ];
 
     const queue = buildPracticeQueue(records, 'review');
-    expect(queue.map((item) => item.questionId)).toEqual(['q2', 'q3', 'q1']);
+    const ids = queue.map((item) => item.questionId).sort();
+    expect(ids).toEqual(['q1', 'q2', 'q3']);
+    expect(queue).toHaveLength(3);
   });
 
   it('builds weighted sprint queue', () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,12 +87,12 @@ export default function Home() {
             <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-50 text-emerald-600 transition-colors group-hover:bg-emerald-100">
               <TrendingUp className="h-6 w-6" />
             </div>
-            <h3 className="mb-2 text-xl font-bold text-slate-900">学习进度</h3>
+            <h3 className="mb-2 text-xl font-bold text-slate-900">学习管理</h3>
             <p className="mb-6 text-sm text-slate-500">
-              追踪你的正确率与掌握程度，发现薄弱环节。
+              追踪练习进度，管理错题与收藏，发现薄弱环节。
             </p>
             <div className="flex items-center text-sm font-semibold text-emerald-600 transition-transform group-hover:translate-x-1">
-              查看统计 <ChevronRight className="ml-1 h-4 w-4" />
+              进入管理 <ChevronRight className="ml-1 h-4 w-4" />
             </div>
           </Link>
 

--- a/src/hooks/useTopicProgress.ts
+++ b/src/hooks/useTopicProgress.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// 每个主题的进度记录
+export interface TopicProgressRecord {
+    topicId: string;
+    totalAnswered: number;   // 总答题数
+    correctCount: number;    // 正确数
+    lastPracticeAt: number;  // 最近练习时间
+}
+
+interface TopicProgressState {
+    progress: Record<string, TopicProgressRecord>;
+
+    // Actions
+    recordAnswer: (topicId: string, isCorrect: boolean) => void;
+    getTopicProgress: (topicId: string) => TopicProgressRecord | undefined;
+    resetTopicProgress: (topicId: string) => void;
+    resetAllProgress: () => void;
+}
+
+export const useTopicProgress = create<TopicProgressState>()(
+    persist(
+        (set, get) => ({
+            progress: {},
+
+            recordAnswer: (topicId: string, isCorrect: boolean) => {
+                set((state) => {
+                    const existing = state.progress[topicId];
+                    return {
+                        progress: {
+                            ...state.progress,
+                            [topicId]: {
+                                topicId,
+                                totalAnswered: existing ? existing.totalAnswered + 1 : 1,
+                                correctCount: existing
+                                    ? existing.correctCount + (isCorrect ? 1 : 0)
+                                    : isCorrect ? 1 : 0,
+                                lastPracticeAt: Date.now(),
+                            },
+                        },
+                    };
+                });
+            },
+
+            getTopicProgress: (topicId: string) => {
+                return get().progress[topicId];
+            },
+
+            resetTopicProgress: (topicId: string) => {
+                set((state) => {
+                    const { [topicId]: _, ...rest } = state.progress;
+                    return { progress: rest };
+                });
+            },
+
+            resetAllProgress: () => {
+                set({ progress: {} });
+            },
+        }),
+        {
+            name: 'topic-progress-storage',
+        }
+    )
+);

--- a/src/hooks/useTopicQuiz.ts
+++ b/src/hooks/useTopicQuiz.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Question, QuizState } from '@/types/quiz';
 import { useUserProgress } from '@/hooks/useUserProgress';
+import { useTopicProgress } from '@/hooks/useTopicProgress';
 
 interface UseTopicQuizReturn extends QuizState {
   currentQuestion: Question | null;
@@ -30,6 +31,7 @@ export default function useTopicQuiz(slug: string): UseTopicQuizReturn {
   });
 
   const { addMistake } = useUserProgress();
+  const { recordAnswer } = useTopicProgress();
 
   useEffect(() => {
     let mounted = true;
@@ -85,6 +87,9 @@ export default function useTopicQuiz(slug: string): UseTopicQuizReturn {
     if (!isCorrect) {
       addMistake(question, slug);
     }
+
+    // Record topic progress
+    recordAnswer(slug, isCorrect);
 
     setState(prev => ({
       ...prev,

--- a/src/lib/mistakeFilters.ts
+++ b/src/lib/mistakeFilters.ts
@@ -60,13 +60,8 @@ function shuffleArray<T>(items: T[], randomFn: () => number): T[] {
   return copied;
 }
 
-function buildReviewQueue(records: MistakeRecord[]): MistakeRecord[] {
-  return [...records].sort((a, b) => {
-    if (b.count !== a.count) {
-      return b.count - a.count;
-    }
-    return b.lastWrongAt - a.lastWrongAt;
-  });
+function buildReviewQueue(records: MistakeRecord[], randomFn: () => number): MistakeRecord[] {
+  return shuffleArray([...records], randomFn);
 }
 
 function buildSprintQueue(records: MistakeRecord[], randomFn: () => number): MistakeRecord[] {
@@ -91,5 +86,5 @@ export function buildPracticeQueue(
     return buildSprintQueue(records, randomFn);
   }
 
-  return buildReviewQueue(records);
+  return buildReviewQueue(records, randomFn);
 }


### PR DESCRIPTION
- 新增 useTopicProgress zustand store，持久化记录各主题答题进度
- useTopicQuiz 答题时同步写入主题进度
- 重构 /progress 页面为学习管理仪表盘（主题练习/错题本/收藏三卡片）
- 首页「学习进度」→「学习管理」
- 错题复习模式改为随机出题，新增打乱题序按钮
- 更新 mistakeFilters 测试适配随机队列