### PR TITLE
修复：错题本重复答错不累计次数

### DIFF
--- a/src/__tests__/MistakesPracticeCard.test.tsx
+++ b/src/__tests__/MistakesPracticeCard.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MistakesPracticeCard from '@/components/exam/MistakesPracticeCard';
 import { MistakeRecord } from '@/hooks/useUserProgress';
+
+const mockAddMistake = vi.fn();
 
 const mockMistakes: Record<string, MistakeRecord> = {
   q1: {
@@ -29,7 +31,7 @@ vi.mock('@/hooks/useUserProgress', () => ({
     isBookmarked: vi.fn(() => false),
     toggleBookmark: vi.fn(),
     removeMistake: vi.fn(),
-    addMistake: vi.fn(),
+    addMistake: mockAddMistake,
     removeBookmark: vi.fn(),
     isMistake: vi.fn(() => false),
     clearAllMistakes: vi.fn(),
@@ -38,6 +40,10 @@ vi.mock('@/hooks/useUserProgress', () => ({
 }));
 
 describe('MistakesPracticeCard', () => {
+  beforeEach(() => {
+    mockAddMistake.mockClear();
+  });
+
   it('keeps full filter controls after empty result', () => {
     render(<MistakesPracticeCard />);
 
@@ -46,5 +52,17 @@ describe('MistakesPracticeCard', () => {
     expect(screen.getByText('当前筛选下暂无错题')).toBeDefined();
     expect(screen.getByText('错 >= 2 次')).toBeDefined();
     expect(screen.getByText('复习模式')).toBeDefined();
+  });
+
+  it('records mistake again when answered incorrectly in mistakes practice', () => {
+    render(<MistakesPracticeCard />);
+
+    fireEvent.click(screen.getByText('B'));
+
+    expect(mockAddMistake).toHaveBeenCalledTimes(1);
+    expect(mockAddMistake).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'q1' }),
+      'history'
+    );
   });
 });

--- a/src/components/exam/MistakesPracticeCard.tsx
+++ b/src/components/exam/MistakesPracticeCard.tsx
@@ -22,10 +22,10 @@ import {
   PracticeMode,
 } from '@/lib/mistakeFilters';
 
-// 定义错题过滤器
+// 定义错题过滤器，只允许取特定值
 type WrongCountFilter = 1 | 2 | 3 | 5;
 
-
+// 定义常变量 
 const TOPIC_CN: Record<string, string> = {
   values: '原则与价值观',
   institutions: '制度体系',
@@ -83,7 +83,7 @@ export default function MistakesPracticeCard() {
   const [sessionCorrect, setSessionCorrect] = useState(0);
   const [shuffleKey, setShuffleKey] = useState(0);
 
-  const { mistakes, isBookmarked, toggleBookmark, removeMistake } = useUserProgress();
+  const { mistakes, isBookmarked, toggleBookmark, removeMistake, addMistake } = useUserProgress();
 
   const sortedMistakes = useMemo(
     () => Object.values(mistakes).sort((a, b) => b.count - a.count || b.lastWrongAt - a.lastWrongAt),
@@ -173,8 +173,11 @@ export default function MistakesPracticeCard() {
     setSessionAnswered((prev) => prev + 1);
     if (isCorrect) {
       setSessionCorrect((prev) => prev + 1);
-    } else if (mode === 'sprint') {
-      setExtraQueue((prev) => [...prev, currentRecord.questionId]);
+    } else {
+      addMistake(currentQuestion, currentRecord.topicId);
+      if (mode === 'sprint') {
+        setExtraQueue((prev) => [...prev, currentRecord.questionId]);
+      }
     }
   };
 


### PR DESCRIPTION
## 背景
在刷错题本场景中，同一题再次答错时没有累加错题次数，导致错题权重与统计不准确。

## 变更
- 在错题本练习组件中补充 `addMistake` 的调用
- 当用户在错题本答错时，立即记录一次错题（`count + 1`）
- 保留冲刺模式原有的重入队列行为
- 补充回归测试，覆盖“错题本答错会再次记录”

## 验证
- `npm run test -- MistakesPracticeCard`
- 结果：1 个测试文件通过，2 条用例通过
