### PR TITLE
迁移数据库到 Supabase 并支持 SQLite 全量迁移

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@libsql/client": "^0.17.0",
         "@prisma/adapter-libsql": "^7.3.0",
+        "@prisma/adapter-pg": "^7.3.0",
         "@prisma/client": "^7.3.0",
         "framer-motion": "^12.29.3",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
+        "pg": "^8.18.0",
         "prisma": "^7.3.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -24,6 +26,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
+        "@types/pg": "^8.16.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.1.3",
@@ -2382,6 +2385,17 @@
         "@libsql/win32-x64-msvc": "0.3.19"
       }
     },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.3.0.tgz",
+      "integrity": "sha512-iuYQMbIPO6i9O45Fv8TB7vWu00BXhCaNAShenqF7gLExGDbnGp5BfFB4yz1K59zQ59jF6tQ9YHrg0P6/J3OoLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.3.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.3.0.tgz",
@@ -3361,6 +3375,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -8206,6 +8232,104 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8286,6 +8410,45 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -9033,6 +9196,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sqlstring": {
@@ -10165,6 +10337,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,19 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest"
+    "test": "vitest",
+    "db:push": "prisma db push",
+    "db:migrate:sqlite-to-supabase": "tsx scripts/migrate-sqlite-to-supabase.ts"
   },
   "dependencies": {
     "@libsql/client": "^0.17.0",
     "@prisma/adapter-libsql": "^7.3.0",
+    "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "^7.3.0",
     "framer-motion": "^12.29.3",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
+    "pg": "^8.18.0",
     "prisma": "^7.3.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -26,6 +30,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
+    "@types/pg": "^8.16.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.1.3",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
     seed: "npx tsx prisma/seed.ts",
   },
   datasource: {
-    url: process.env["DATABASE_URL"],
+    url: process.env["DIRECT_URL"] || process.env["DATABASE_URL"],
   },
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
 }
 
 model Category {
@@ -37,16 +37,19 @@ model Choice {
 }
 
 model User {
-  id           String    @id @default(cuid())
-  account      String    @unique
-  passwordHash String
-  nickname     String
-  role         String    @default("USER")
-  plan         String    @default("FREE")
-  status       String    @default("ACTIVE")
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  sessions     Session[]
+  id                String             @id @default(cuid())
+  account           String             @unique
+  passwordHash      String
+  nickname          String
+  role              String             @default("USER")
+  plan              String             @default("FREE")
+  status            String             @default("ACTIVE")
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+  sessions          Session[]
+  mistakes          UserMistake[]
+  topicProgresses   UserTopicProgress[]
+  bookmarks         UserBookmark[]
 }
 
 model Session {
@@ -56,4 +59,50 @@ model Session {
   expiresAt    DateTime
   createdAt    DateTime @default(now())
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model UserMistake {
+  id           String   @id @default(cuid())
+  userId       String
+  questionId   String
+  questionJson String
+  topicId      String
+  count        Int      @default(1)
+  lastWrongAt  DateTime
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, questionId])
+  @@index([userId])
+}
+
+model UserTopicProgress {
+  id           String   @id @default(cuid())
+  userId       String
+  topicId      String
+  totalAnswered Int     @default(0)
+  correctCount Int      @default(0)
+  lastPracticeAt DateTime
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, topicId])
+  @@index([userId])
+}
+
+model UserBookmark {
+  id           String   @id @default(cuid())
+  userId       String
+  questionId   String
+  questionJson String
+  topicId      String
+  addedAt      DateTime
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, questionId])
+  @@index([userId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,13 +1,16 @@
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSql } from "@prisma/adapter-libsql";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 import * as fs from "fs";
 import * as path from "path";
 
-// 创建 adapter
-const adapter = new PrismaLibSql({
-    url: "file:dev.db",
-});
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+    throw new Error("缺少 DATABASE_URL 环境变量");
+}
 
+const pool = new Pool({ connectionString });
+const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 
 interface JsonChoice {
@@ -151,4 +154,5 @@ main()
     })
     .finally(async () => {
         await prisma.$disconnect();
+        await pool.end();
     });

--- a/scripts/migrate-sqlite-to-supabase.ts
+++ b/scripts/migrate-sqlite-to-supabase.ts
@@ -1,0 +1,436 @@
+import "dotenv/config";
+
+import { createClient } from "@libsql/client";
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+
+const SQLITE_URL = process.env.SQLITE_URL ?? "file:dev.db";
+const PG_URL = process.env.DATABASE_URL;
+
+if (!PG_URL) {
+  throw new Error("缺少 DATABASE_URL，请先配置 .env");
+}
+
+const sqlite = createClient({ url: SQLITE_URL });
+const pool = new Pool({ connectionString: PG_URL });
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+type TableName =
+  | "Category"
+  | "Question"
+  | "Choice"
+  | "User"
+  | "Session"
+  | "UserMistake"
+  | "UserTopicProgress"
+  | "UserBookmark";
+
+type SQLiteCounts = Record<TableName, number>;
+
+type CategoryRow = { id: string; title: string };
+type QuestionRow = {
+  id: string;
+  type: string;
+  stem: string;
+  stemZh: string | null;
+  analysis: string;
+  analysisZh: string | null;
+  difficulty: number;
+  tags: string | null;
+  categoryId: string;
+};
+type ChoiceRow = {
+  id: string;
+  originalId: string;
+  text: string;
+  textZh: string | null;
+  isCorrect: number | boolean;
+  questionId: string;
+};
+type UserRow = {
+  id: string;
+  account: string;
+  passwordHash: string;
+  nickname: string;
+  role: string;
+  plan: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+};
+type SessionRow = {
+  id: string;
+  tokenHash: string;
+  userId: string;
+  expiresAt: string;
+  createdAt: string;
+};
+type UserMistakeRow = {
+  id: string;
+  userId: string;
+  questionId: string;
+  questionJson: string;
+  topicId: string;
+  count: number;
+  lastWrongAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+type UserTopicProgressRow = {
+  id: string;
+  userId: string;
+  topicId: string;
+  totalAnswered: number;
+  correctCount: number;
+  lastPracticeAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+type UserBookmarkRow = {
+  id: string;
+  userId: string;
+  questionId: string;
+  questionJson: string;
+  topicId: string;
+  addedAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function asBool(value: number | boolean): boolean {
+  if (typeof value === "boolean") return value;
+  return value === 1;
+}
+
+function asDate(value: string): Date {
+  return new Date(value);
+}
+
+async function querySQLite<T>(sql: string): Promise<T[]> {
+  const result = await sqlite.execute(sql);
+  return result.rows as unknown as T[];
+}
+
+async function getSQLiteCounts(): Promise<SQLiteCounts> {
+  const sql = `
+    SELECT 'Category' AS name, COUNT(*) AS count FROM Category
+    UNION ALL SELECT 'Question', COUNT(*) FROM Question
+    UNION ALL SELECT 'Choice', COUNT(*) FROM Choice
+    UNION ALL SELECT 'User', COUNT(*) FROM User
+    UNION ALL SELECT 'Session', COUNT(*) FROM Session
+    UNION ALL SELECT 'UserMistake', COUNT(*) FROM UserMistake
+    UNION ALL SELECT 'UserTopicProgress', COUNT(*) FROM UserTopicProgress
+    UNION ALL SELECT 'UserBookmark', COUNT(*) FROM UserBookmark
+  `;
+  const rows = await querySQLite<{ name: TableName; count: number }>(sql);
+
+  const counts: SQLiteCounts = {
+    Category: 0,
+    Question: 0,
+    Choice: 0,
+    User: 0,
+    Session: 0,
+    UserMistake: 0,
+    UserTopicProgress: 0,
+    UserBookmark: 0,
+  };
+
+  for (const row of rows) {
+    counts[row.name] = Number(row.count);
+  }
+
+  return counts;
+}
+
+async function getPGCounts() {
+  const [category, question, choice, user, session, userMistake, userTopicProgress, userBookmark] =
+    await Promise.all([
+      prisma.category.count(),
+      prisma.question.count(),
+      prisma.choice.count(),
+      prisma.user.count(),
+      prisma.session.count(),
+      prisma.userMistake.count(),
+      prisma.userTopicProgress.count(),
+      prisma.userBookmark.count(),
+    ]);
+
+  return {
+    Category: category,
+    Question: question,
+    Choice: choice,
+    User: user,
+    Session: session,
+    UserMistake: userMistake,
+    UserTopicProgress: userTopicProgress,
+    UserBookmark: userBookmark,
+  };
+}
+
+function printCounts(title: string, counts: Record<TableName, number>) {
+  console.log(`\n${title}`);
+  for (const [table, count] of Object.entries(counts)) {
+    console.log(`- ${table}: ${count}`);
+  }
+}
+
+async function migrateCategories() {
+  const rows = await querySQLite<CategoryRow>('SELECT id, title FROM "Category"');
+  for (const row of rows) {
+    await prisma.category.upsert({
+      where: { id: row.id },
+      update: { title: row.title },
+      create: { id: row.id, title: row.title },
+    });
+  }
+}
+
+async function migrateQuestions() {
+  const rows = await querySQLite<QuestionRow>(
+    'SELECT id, type, stem, stemZh, analysis, analysisZh, difficulty, tags, categoryId FROM "Question"',
+  );
+  for (const row of rows) {
+    await prisma.question.upsert({
+      where: { id: row.id },
+      update: {
+        type: row.type,
+        stem: row.stem,
+        stemZh: row.stemZh,
+        analysis: row.analysis,
+        analysisZh: row.analysisZh,
+        difficulty: Number(row.difficulty),
+        tags: row.tags,
+        categoryId: row.categoryId,
+      },
+      create: {
+        id: row.id,
+        type: row.type,
+        stem: row.stem,
+        stemZh: row.stemZh,
+        analysis: row.analysis,
+        analysisZh: row.analysisZh,
+        difficulty: Number(row.difficulty),
+        tags: row.tags,
+        categoryId: row.categoryId,
+      },
+    });
+  }
+}
+
+async function migrateChoices() {
+  const rows = await querySQLite<ChoiceRow>(
+    'SELECT id, originalId, text, textZh, isCorrect, questionId FROM "Choice"',
+  );
+  for (const row of rows) {
+    await prisma.choice.upsert({
+      where: { id: row.id },
+      update: {
+        originalId: row.originalId,
+        text: row.text,
+        textZh: row.textZh,
+        isCorrect: asBool(row.isCorrect),
+        questionId: row.questionId,
+      },
+      create: {
+        id: row.id,
+        originalId: row.originalId,
+        text: row.text,
+        textZh: row.textZh,
+        isCorrect: asBool(row.isCorrect),
+        questionId: row.questionId,
+      },
+    });
+  }
+}
+
+async function migrateUsers() {
+  const rows = await querySQLite<UserRow>(
+    'SELECT id, account, passwordHash, nickname, role, plan, status, createdAt, updatedAt FROM "User"',
+  );
+  for (const row of rows) {
+    await prisma.user.upsert({
+      where: { id: row.id },
+      update: {
+        account: row.account,
+        passwordHash: row.passwordHash,
+        nickname: row.nickname,
+        role: row.role,
+        plan: row.plan,
+        status: row.status,
+        createdAt: asDate(row.createdAt),
+      },
+      create: {
+        id: row.id,
+        account: row.account,
+        passwordHash: row.passwordHash,
+        nickname: row.nickname,
+        role: row.role,
+        plan: row.plan,
+        status: row.status,
+        createdAt: asDate(row.createdAt),
+      },
+    });
+  }
+}
+
+async function migrateSessions() {
+  const rows = await querySQLite<SessionRow>(
+    'SELECT id, tokenHash, userId, expiresAt, createdAt FROM "Session"',
+  );
+  for (const row of rows) {
+    await prisma.session.upsert({
+      where: { id: row.id },
+      update: {
+        tokenHash: row.tokenHash,
+        userId: row.userId,
+        expiresAt: asDate(row.expiresAt),
+        createdAt: asDate(row.createdAt),
+      },
+      create: {
+        id: row.id,
+        tokenHash: row.tokenHash,
+        userId: row.userId,
+        expiresAt: asDate(row.expiresAt),
+        createdAt: asDate(row.createdAt),
+      },
+    });
+  }
+}
+
+async function migrateUserMistakes() {
+  const rows = await querySQLite<UserMistakeRow>(
+    'SELECT id, userId, questionId, questionJson, topicId, count, lastWrongAt, createdAt, updatedAt FROM "UserMistake"',
+  );
+  for (const row of rows) {
+    await prisma.userMistake.upsert({
+      where: {
+        userId_questionId: {
+          userId: row.userId,
+          questionId: row.questionId,
+        },
+      },
+      update: {
+        questionJson: row.questionJson,
+        topicId: row.topicId,
+        count: Number(row.count),
+        lastWrongAt: asDate(row.lastWrongAt),
+        createdAt: asDate(row.createdAt),
+        updatedAt: asDate(row.updatedAt),
+      },
+      create: {
+        id: row.id,
+        userId: row.userId,
+        questionId: row.questionId,
+        questionJson: row.questionJson,
+        topicId: row.topicId,
+        count: Number(row.count),
+        lastWrongAt: asDate(row.lastWrongAt),
+        createdAt: asDate(row.createdAt),
+        updatedAt: asDate(row.updatedAt),
+      },
+    });
+  }
+}
+
+async function migrateUserTopicProgresses() {
+  const rows = await querySQLite<UserTopicProgressRow>(
+    'SELECT id, userId, topicId, totalAnswered, correctCount, lastPracticeAt, createdAt, updatedAt FROM "UserTopicProgress"',
+  );
+  for (const row of rows) {
+    await prisma.userTopicProgress.upsert({
+      where: {
+        userId_topicId: {
+          userId: row.userId,
+          topicId: row.topicId,
+        },
+      },
+      update: {
+        totalAnswered: Number(row.totalAnswered),
+        correctCount: Number(row.correctCount),
+        lastPracticeAt: asDate(row.lastPracticeAt),
+        createdAt: asDate(row.createdAt),
+        updatedAt: asDate(row.updatedAt),
+      },
+      create: {
+        id: row.id,
+        userId: row.userId,
+        topicId: row.topicId,
+        totalAnswered: Number(row.totalAnswered),
+        correctCount: Number(row.correctCount),
+        lastPracticeAt: asDate(row.lastPracticeAt),
+        createdAt: asDate(row.createdAt),
+        updatedAt: asDate(row.updatedAt),
+      },
+    });
+  }
+}
+
+async function migrateUserBookmarks() {
+  const rows = await querySQLite<UserBookmarkRow>(
+    'SELECT id, userId, questionId, questionJson, topicId, addedAt, createdAt, updatedAt FROM "UserBookmark"',
+  );
+  for (const row of rows) {
+    await prisma.userBookmark.upsert({
+      where: {
+        userId_questionId: {
+          userId: row.userId,
+          questionId: row.questionId,
+        },
+      },
+      update: {
+        questionJson: row.questionJson,
+        topicId: row.topicId,
+        addedAt: asDate(row.addedAt),
+        createdAt: asDate(row.createdAt),
+        updatedAt: asDate(row.updatedAt),
+      },
+      create: {
+        id: row.id,
+        userId: row.userId,
+        questionId: row.questionId,
+        questionJson: row.questionJson,
+        topicId: row.topicId,
+        addedAt: asDate(row.addedAt),
+        createdAt: asDate(row.createdAt),
+        updatedAt: asDate(row.updatedAt),
+      },
+    });
+  }
+}
+
+async function main() {
+  console.log("开始迁移 SQLite -> Supabase(Postgres)...");
+  console.log(`SQLite 源: ${SQLITE_URL}`);
+
+  const sourceBefore = await getSQLiteCounts();
+  const targetBefore = await getPGCounts();
+
+  printCounts("源库计数", sourceBefore);
+  printCounts("目标库迁移前计数", targetBefore);
+
+  await migrateCategories();
+  await migrateQuestions();
+  await migrateChoices();
+  await migrateUsers();
+  await migrateSessions();
+  await migrateUserMistakes();
+  await migrateUserTopicProgresses();
+  await migrateUserBookmarks();
+
+  const targetAfter = await getPGCounts();
+  printCounts("目标库迁移后计数", targetAfter);
+
+  console.log("\n迁移完成。可重复执行（upsert 幂等）。");
+}
+
+main()
+  .catch((error) => {
+    console.error("迁移失败:", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+    await pool.end();
+    sqlite.close();
+  });

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,9 +1,14 @@
 import { PrismaClient } from "@prisma/client";
-import { PrismaLibSql } from "@prisma/adapter-libsql";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
-const adapter = new PrismaLibSql({
-    url: "file:dev.db",
-});
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+    throw new Error("缺少 DATABASE_URL 环境变量");
+}
+
+const pool = new Pool({ connectionString });
+const adapter = new PrismaPg(pool);
 
 const globalForPrisma = globalThis as unknown as {
     prisma: PrismaClient | undefined;


### PR DESCRIPTION
## 背景
将项目数据源从本地 SQLite 切换到 Supabase PostgreSQL，并保留现有登录体系（User/Session）。

## 主要改动
- Prisma 数据源切换为 PostgreSQL（Prisma 7 配置）
- 运行时 Prisma 客户端改为 PG adapter
- seed 脚本改为连接 PostgreSQL
- 补齐 UserMistake / UserTopicProgress / UserBookmark 三张模型
- 新增一次性迁移脚本 scripts/migrate-sqlite-to-supabase.ts（从 dev.db 全量迁移到 Supabase，upsert 幂等）
- 新增 npm 脚本：db:push、db:migrate:sqlite-to-supabase

## 验证结果
- npm run db:push：通过
- npm run db:migrate:sqlite-to-supabase：通过
- 迁移后计数与源库一致：
  - Category: 5
  - Question: 203
  - Choice: 812
  - User: 2
  - Session: 4
  - UserMistake: 3
  - UserTopicProgress: 1
  - UserBookmark: 0

## 说明
- 本 PR 不包含页面业务逻辑改动，仅包含数据库上云相关代码。
